### PR TITLE
alternative linux icon fix

### DIFF
--- a/enhancedsteam.js
+++ b/enhancedsteam.js
@@ -3066,7 +3066,7 @@ function alternative_linux_icon() {
 	storage.get(function(settings) {
 		if (settings.show_alternative_linux_icon === undefined) { settings.show_alternative_linux_icon = false; storage.set({'show_alternative_linux_icon': settings.show_alternative_linux_icon}); }
 		if (settings.show_alternative_linux_icon) {
-			$("head").append("<style>span.platform_img.linux {background-image: url("+chrome.extension.getURL("img/alternative_linux_icon.png")+")}</style>")
+			$("head").append("<style>span.platform_img.linux {background-image: url("+chrome.extension.getURL("img/alternative_linux_icon.png")+") !important}</style>")
 		}
 	});
 }


### PR DESCRIPTION
I noticed that the alternative linux icon is not displayed. This small change fixes that.