### PR TITLE
Add platform images only inside span.es_platform elts, use https:

### DIFF
--- a/css/enhancedsteam.css
+++ b/css/enhancedsteam.css
@@ -12,28 +12,28 @@
 	margin: auto;
 }
 
-span.platform_img {
+span.es_platform > span.platform_img {
 	display: inline-block;
 	width: 22px;
 	height: 22px;
 	background-repeat: no-repeat;
 }
 
-span.platform_img.steamplay {
+span.es_platform > span.platform_img.steamplay {
 	width: 72px;
-	background-image: url( '//steamstore-a.akamaihd.net/public/images/v6/icon_steamplay.png' );
+	background-image: url( 'https://steamstore-a.akamaihd.net/public/images/v6/icon_steamplay.png' );
 }
 
-span.platform_img.win {
-	background-image: url( '//steamstore-a.akamaihd.net/public/images/v6/icon_platform_win.png' );
+span.es_platform > span.platform_img.win {
+	background-image: url( 'https://steamstore-a.akamaihd.net/public/images/v6/icon_platform_win.png' );
 }
 
-span.platform_img.mac {
-	background-image: url( '//steamstore-a.akamaihd.net/public/images/v6/icon_platform_mac.png' );
+span.es_platform > span.platform_img.mac {
+	background-image: url( 'https://steamstore-a.akamaihd.net/public/images/v6/icon_platform_mac.png' );
 }
 
-span.platform_img.linux {
-	background-image: url( '//steamstore-a.akamaihd.net/public/images/v6/icon_platform_linux.png' );
+span.es_platform > span.platform_img.linux {
+	background-image: url( 'https://steamstore-a.akamaihd.net/public/images/v6/icon_platform_linux.png' );
 }
 
 img.platform_small, .platform_img {


### PR DESCRIPTION
Here's a draft fix for issue 114. 
 1. Make the 4 rules here that provide platform icons only apply inside <span class="es_platform"> elements.
 2. Use https://... URLs for the platform images, avoiding 'mixed content' warnings